### PR TITLE
Support for yuv422_yuy2 input image format + minor fixes

### DIFF
--- a/ros2_h264_encoder/include/ros2_h264_encoder/ros2_encoder.hpp
+++ b/ros2_h264_encoder/include/ros2_h264_encoder/ros2_encoder.hpp
@@ -59,6 +59,7 @@ private:
         formats[sensor_msgs::image_encodings::RGB8] = AV_PIX_FMT_RGB24;        
         formats[sensor_msgs::image_encodings::RGBA16] = AV_PIX_FMT_RGBA64;
         formats[sensor_msgs::image_encodings::RGBA8] = AV_PIX_FMT_RGBA;
+        formats[sensor_msgs::image_encodings::YUV422_YUY2] = AV_PIX_FMT_YUYV422;
         return formats;
     }
 

--- a/ros2_h264_encoder/package.xml
+++ b/ros2_h264_encoder/package.xml
@@ -16,6 +16,8 @@
   <depend>h264_msgs</depend>  
   <depend>rclcpp</depend>
   <depend>image_transport</depend>
+  <depend>libswscale-dev</depend>
+  <depend>libx264-dev</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/ros2_h264_encoder/src/ros2_encoder.cpp
+++ b/ros2_h264_encoder/src/ros2_encoder.cpp
@@ -59,7 +59,7 @@ bool ROS2Encoder::encode_image(const sensor_msgs::msg::Image &msg, h264_msgs::ms
 }
     
 bool ROS2Encoder::convert_image_to_h264(const sensor_msgs::msg::Image &msg, x264_picture_t* out) {
-    int stride[3] = {static_cast<int>(msg.width) * 3, 0, 0};
+    int stride[3] = {static_cast<int>(msg.step), 0, 0};
     uint8_t *src[3]= {const_cast<uint8_t *>(&msg.data[0]), NULL, NULL};
     int returnedHeight = sws_scale(conversion_context, src, stride, 0, params.i_height, out->img.plane, out->img.i_stride);
     out->i_pts = pts;


### PR DESCRIPTION
Just minor fixes/enhancements
 * installation simplification using rosdep
 * fixed stride for non-24-bit image encodings
 * added one such encoding - yuv422_yuy2. I don't know if `opencv_cam` can publish in such format, but it is supported by e.g. `usb_cam` package (its benefits are that it can be installed via `sudo apt install ros-humble-usb-cam`, no need for submoduling and building from source + supports e.g. pausing/resuming of camera)